### PR TITLE
Require any version of ext-json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^7.2",
         "ext-curl": "^7.1",
-        "ext-json": "^1.5"
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`^1.5` sometime fails
```
tde/mgapi v1.8.4 requires ext-json ^1.5 -> it has the wrong version (7.4.16) installed. Install or enable PHP's json extension.
```